### PR TITLE
Updates manubot version to include title/keyword fix

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pip:
     - cffi==1.15.0
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@6e6f6a5aac381120faf3ef02e594b5babc77da2b
+    - git+https://github.com/manubot/manubot@06fcecb4f9eaf9c62f804e0213e9a905c82725e4
     - isbnlib==3.10.10
     - opentimestamps-client==0.7.1
     - opentimestamps==0.4.3


### PR DESCRIPTION
This PR updates manubot to a version that includes the PR https://github.com/manubot/manubot/pull/370, which fixes title/keyword propagation for models that descend from `GPT3CompletionModel`, not just that model itself.